### PR TITLE
Bump build number to rebuild with a newer `conda-build`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda = conda.cli:main
   always_include_files:
@@ -44,12 +44,6 @@ requirements:
   build:
     - python
     - setuptools
-    - conda-env >=2.5
-    - menuinst                  # [win]
-    - pycosat
-    - pyyaml
-    - requests
-    - ruamel_yaml
 
   run:
     - python


### PR DESCRIPTION
The current `conda` package includes some `__pycache__` directories in Python 3 builds for its dependencies (`setuptools` and `pkg_resources`. Current [thinking]( https://github.com/conda-forge/conda-smithy/issues/289#issuecomment-244097434 ) is this is fixed in more recent `conda-build`s than were used to build the current package. So am proposing a build number bump in order to get fresh packages out that don't have this problem. As an additional safety measure, have dropped any unneeded build dependencies.

However, I'm finding that these are still being picked up from dependencies when building locally in the docker container. It seems which directories get picked up is somewhat arbitrary, which is disconcerting. Maybe this PR will at least provide a common base for this discussion to proceed.

xref: https://github.com/conda-forge/conda-smithy/issues/289

cc @msarahan