### PR TITLE
Adds missing `conda-env` entrypoint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - enum34                 # [py<34]
     - menuinst               # [win]
     - pycosat >=0.6.1
+    - pyyaml
     - requests >=2.5.3
     - ruamel_yaml >=0.11.14
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
   number: 0
   entry_points:
     - conda = conda.cli:main
+    - conda-env = conda_env.cli.main:main
   always_include_files:
     - bin/conda                            # [unix]
     - bin/activate                         # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,8 +60,11 @@ test:
   commands:
     - which conda                  # [unix]
     - where conda                  # [win]
+    - which conda-env              # [unix]
+    - where conda-env              # [win]
     - conda --version
     - conda info
+    - conda env --help
 
 about:
   home: https://github.com/conda/conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda = conda.cli:main
     - conda-env = conda_env.cli.main:main


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-feedstock/issues/11

This adds an entry point for `conda-env` to the recipe.

cc @frol @kalefranz
