### PR TITLE
WIP: Release 4.2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search conda --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
@@ -14,6 +12,8 @@ environment:
   # We set a default Python version for the miniconda that is to be installed. This can be
   # overridden in the matrix definition where appropriate.
   CONDA_PY: "27"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +21,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +62,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
-{% set version = "4.2.11" %}
-{% set checksum = "7cc6696aaf50d1ff5ce502f99c7062ce4258dadfb0fb94b01874c999c929f3c2" %}
+{% set version = "4.2.12" %}
+{% set checksum = "a81cd38441258ff7bd8e053d472191cb01cb2772f5f2110ac86fc79c69b5c5c7" %}
 
 package:
   name: conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,8 +59,11 @@ test:
   commands:
     - which conda                  # [unix]
     - where conda                  # [win]
+    - which conda-env              # [unix]
+    - where conda-env              # [win]
     - conda --version
     - conda info
+    - conda env --help
 
 about:
   home: https://github.com/conda/conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
   number: 0
   entry_points:
     - conda = conda.cli:main
+    - conda-env = conda_env.cli.main:main
   always_include_files:
     - bin/conda                            # [unix]
     - bin/activate                         # [unix]


### PR DESCRIPTION
```markdown
## 4.2.12

### Bug Fixes

* fix #3732, #3471, #3744 CONDA_BLD_PATH (#3747)
* fix #3717 allow no-name channels (#3748)
* fix #3738 move conda-env to ruamel_yaml (#3740)
* fix conda-env entry point (#3745 via #3743)
* fix again #3664 trash emptying (#3746)
```

---

Closes https://github.com/conda-forge/conda-feedstock/pull/12
Fixes https://github.com/conda-forge/conda-feedstock/issues/11

---

* Re-renders with `conda-smithy` version `1.4.6`.
* Adds the `conda env entry point. 
* Adds a few tests for `conda env`.
* Releases 4.2.12.

---

cc @frol @kalefranz