### PR TITLE
Add core

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,10 +76,10 @@ extra:
     - jjhelmus
     - kalefranz
     - mcg1969
+    - mingwandroid
     - msarahan
     - mwcraig
     - ocefpaf
     - patricksnape
     - pelson
-    - mingwandroid
     - scopatz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,8 +73,13 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - jjhelmus
     - kalefranz
     - mcg1969
     - msarahan
+    - mwcraig
+    - ocefpaf
+    - patricksnape
     - pelson
     - mingwandroid
+    - scopatz


### PR DESCRIPTION
This explicitly adds all of @conda-forge/core as maintainers of `conda`. As this is our `conda` package and determines, which version we are using as latest. It is paramount that all of core explicitly has access should they need it. This provides that access.