### PR TITLE
Release 4.2.16

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
-{% set version = "4.2.13" %}
-{% set checksum = "4a04bbf21dc4274f7623793d2746527c614fea8ca533a8efb252a10c42c34d5d" %}
+{% set version = "4.2.16" %}
+{% set checksum = "e4966bb85a1553032e361568a63fcd8a46495c3b9d50c3b4151369c5b0e04190" %}
 
 package:
   name: conda
@@ -49,7 +49,8 @@ requirements:
     - enum34                 # [py<34]
     - menuinst               # [win]
     - pycosat >=0.6.1
-    - requests >=2.5.3
+    - pyopenssl >=16.2.0
+    - requests >=2.12.4
     - ruamel_yaml >=0.11.14
 
 test:


### PR DESCRIPTION
```markdown
## 4.2.16 (2017-01-20)

### Improvements
* vendor url parsing from urllib3 (#4289)
* workaround for symlink race conditions on activate (#4346)

### Bug Fixes
* do not replace \ with / in file:// URLs on Windows (#4269)
* include aliases for first command-line argument (#4279)
* fix for multi-line FTP status codes (#4276)
* fix errors with unknown type channels (#4291)
* change sys.exit to raise UpgradeError when info/files not found (#4388)

### Non-User-Facing Changes
* start using doctests in test runs and coverage (#4304)
* additional package pinning tests (#4312)


## 4.2.15 (2017-01-10)

### Improvements
* use 'post' instead of 'dev' for commits according to PEP-440 (#4234)
* do not use IFS to find activate/deactivate scripts to source (#4243)
* fix relative path to python in activate.bat (#4244)

### Bug Fixes
* replace sed with python for activate and deactivate #4257


## 4.2.14 (2017-01-07)

### Improvements
* use install.rm_rf for TemporaryDirectory cleanup (#3425)
* improve handling of local dependency information (#2107)
* add default channels to exports for Windows and Unix (#4103)
* make subdir configurable (#4178)

### Bug Fixes
* fix conda/install.py single-file behavior (#3854)
* fix the api->conda substitution (#3456)
* fix silent directory removal (#3730)
* fix location of temporary hard links of index.json (#3975)
* fix potential errors in multi-channel export and offline clone (#3995)
* fix auxlib/packaging, git hashes are not limited to 7 characters (#4189)
* fix compatibility with requests >=2.12, add pyopenssl as dependency (#4059)
* fix #3287 activate in 4.1-4.2.3 clobbers non-conda PATH changes (#4211)

### Non-User-Facing Changes
* fix open-ended test failures relating to python 3.6 release (#4166)
* allow args passed to cli.main() (#4193, #4200, #4201)
* test against python 3.6 (#4197)
```