### PR TITLE
Release 4.3.22

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,11 +49,9 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Activate `conda`.
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-
-    # Disable `conda`'s auto-update feature.
-    - cmd: conda config --set auto_update_conda False
+    - cmd: conda update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
-{% set version = "4.3.21" %}
-{% set checksum = "9c079479c4440e09160c06e511ee8f507eaaf22ddc84b1d2d22fee0238169568" %}
+{% set version = "4.3.22" %}
+{% set checksum = "c194ff82edf564989ad68abd89bb1341c0c3f55ea8a3c55da3b22816a574c6bf" %}
 
 package:
   name: conda
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 1
+  number: 0
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.


### PR DESCRIPTION
```markdown
## 4.3.22 (2017-06-12)

### Improvements
* resolve #5428 clean up cli import in conda 4.3.x (#5429)
* resolve #5302 add warning when creating environment with space in path (#5477)
* for ftp connections, ignore host IP from PASV as it is often wrong (#5489)
* expose common race condition exceptions in exports for conda-build (#5498)

### Bug Fixes
* fix #5451 conda clean --json bug (#5452)
* fix #5400 confusing deactivate message (#5473)
* fix #5459 custom subdir channel parsing (#5478)
* fix #5483 problem with setuptools / pkg_resources import (#5496)
```