### PR TITLE
Release 4.3.32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
-{% set version = "4.3.31" %}
-{% set checksum = "70e1fdc5de7b552cd5695b82b672c59bab1251948856bac0dfd81e66eec59138" %}
+{% set version = "4.3.32" %}
+{% set checksum = "bb6069fb7020575f1ee559c2cd01fcf869152e8239bf3a7c556b2e34ed0f6398" %}
 
 package:
   name: conda


### PR DESCRIPTION
```markdown
## 4.3.32 (2018-01-10)

### Improvements
* resolve #6711 fall back to copy/unlink for EINVAL, EXDEV rename failures (#6712)

### Bug Fixes
* fix #6057 unlink-link order for python noarch packages on windows (#6277)
* fix #6509 custom_channels incorrect in 'conda config --show' (#6510)
```