### PR TITLE
Release 4.5.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,21 +1,18 @@
-setlocal enabledelayedexpansion
-
-:: Remove links and other scripts.
-del %PREFIX%\Scripts\activate
-del %PREFIX%\Scripts\activate.bat
-del %PREFIX%\Scripts\deactivate
-del %PREFIX%\Scripts\deactivate.bat
-
-:: Prep conda install
-set CONDA_DEFAULT_ENV=
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+set "WIN_PREFIX=%PREFIX%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
 echo %PKG_VERSION% > conda\.version
-
-:: Install the Python code
-%PYTHON% conda.recipe\setup.py install
-if errorlevel 1 exit 1
-
-:: Install fish activation script.
-mkdir "%PREFIX%\etc\fish\conf.d"
-if errorlevel 1 exit 1
-copy "%SRC_DIR%\shell\conda.fish" "%PREFIX%\etc\fish\conf.d"
+bash -lc ". utils/functions.sh && install_conda_full"
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,17 +1,7 @@
 #!/bin/bash
 
-# Remove symlinks
-unlink $PREFIX/bin/conda
-unlink $PREFIX/bin/activate
-unlink $PREFIX/bin/deactivate
-
 # Prep conda install
-export CONDA_DEFAULT_ENV=''
 echo "${PKG_VERSION}" > conda/.version
 
-# Install the Python code
-$PYTHON conda.recipe/setup.py install
-
-# Install the fish activation script.
-mkdir -p $PREFIX/etc/fish/conf.d/
-cp $SRC_DIR/shell/conda.fish $PREFIX/etc/fish/conf.d/
+# Install conda using bash function
+. utils/functions.sh && install_conda_full

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-{% set name = "conda" %}
 {% set version = "4.3.34" %}
 {% set checksum = "5293ee8c881e175eb627732f488280a662068c50499ffc1f23392cc0a4075ae8" %}
 
@@ -7,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
   sha256: {{ checksum }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,14 +29,18 @@ build:
 requirements:
   build:
     - python
+    - m2-base              # [win]
+    - m2-filesystem        # [win]
+    - m2-git               # [win]
   run:
     - python
     - conda-env >=2.6
     - enum34                 # [py<34]
+    - futures                # [py<34]
     - menuinst               # [win]
-    - pycosat >=0.6.1
+    - pycosat >=0.6.3
     - pyopenssl >=16.2.0
-    - requests >=2.12.4
+    - requests >=2.12.4,<3
     - ruamel_yaml >=0.11.14
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.3.34" %}
-{% set checksum = "5293ee8c881e175eb627732f488280a662068c50499ffc1f23392cc0a4075ae8" %}
+{% set version = "4.5.0" %}
+{% set checksum = "a4210c8d027885d7a5f998c3d58c11882ae7606526f2b555bdab5e5db84f5249" %}
 
 package:
   name: conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ test:
     - conda
 
 about:
-  home: http://conda.pydata.org/
+  home: https://conda.io
   license: BSD 3-Clause
   license_file: LICENSE.txt
   summary: OS-agnostic, system-level binary package and environment manager.
@@ -58,7 +58,7 @@ about:
     and their dependencies and switching easily between them. It works on
     Linux, OS X and Windows, and was created for Python programs but can
     package and distribute any software.
-  doc_url: http://conda.pydata.org/docs/
+  doc_url: https://conda.io/docs/
   dev_url: https://github.com/conda/conda
 
 extra:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -20,7 +20,7 @@ mkdir %CONDA_PKGS_DIRS%
 if errorlevel 1 exit 1
 
 :: Activate the built conda.
-call %PREFIX%\Scripts\activate.bat %PREFIX%
+conda activate base
 if errorlevel 1 exit 1
 
 :: Run conda tests.
@@ -29,7 +29,7 @@ if errorlevel 1 exit 1
 
 :: Deactivate the built conda when done.
 :: Not necessary, but a good test.
-call %PREFIX%\Scripts\deactivate.bat
+conda deactivate
 if errorlevel 1 exit 1
 
 endlocal


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-feedstock/issues/43
Closes https://github.com/conda-forge/conda-feedstock/pull/41

Builds off of PR ( https://github.com/conda-forge/conda-feedstock/pull/41 ). Thanks @kalefranz, @mbargull, and @dougalsutherland for working on that. You deserve all of the credit.

Also expect this will solve issue ( https://github.com/conda-forge/conda-smithy/issues/713 ), which is a `conda-build` 3 blocker and a `conda-smithy` 3 release blocker.

Had trouble getting all of the changes in that PR to work unfortunately. So went back to basics and took exactly what was needed to get it to build on my Mac. Also works on Linux as well (based on testing in the Docker image).

On Windows, I have no way to test this currently. So just lifted those changes from the aforementioned PR. We will see what CI says. If it fails, Windows users...help?

There were some additional tests in the `meta.yaml` from that PR that I wound up dropping. It seems like those tests require `conda-build` 3 to even work correctly; so, dropping them for now may be the best move. In the long run, think we'd like all the tests for `conda` that we can get.

cc @conda-forge/core