### PR TITLE
avoid newer incompatible ruamel_yaml versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.
@@ -41,8 +41,8 @@ requirements:
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
     - requests >=2.12.4,<3
-    - ruamel_yaml >=0.11.14  # [py>27]
-    - ruamel_yaml >=0.11.14,<0.15.39|>=0.15.43  # [py<=27]
+    - ruamel_yaml >=0.11.14,<0.15.55  # [py>27]
+    - ruamel_yaml >=0.11.14,<0.15.39|>=0.15.43,<0.15.55  # [py<=27]
   run_constrained:
     - conda-build >=2.1
     - cytoolz >=0.8.1


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Looks like `conda` didn't like the change of `CommentedSeq`'s base class from `list` to `MutableSequence` in the latest `ruamel.yaml` releases:
```
--- Logging error ---
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/conda/cli/main_config.py", line 30, in execute
    execute_config(args, parser)
  File "/opt/conda/lib/python3.6/site-packages/conda/cli/main_config.py", line 263, in execute_config
    raise CouldntParseError("key %r should be a list, not %s." % (key, bad))
conda.exceptions.CouldntParseError: key 'channels' should be a list, not CommentedSeq.
```
xrefs:
  https://github.com/conda-forge/ruamel_yaml-feedstock/pull/33#issuecomment-414247764
  https://gitter.im/conda-forge/conda-forge.github.io?at=5b7a8525157b9d34efb0e1b6
<!--
Please add any other relevant info below:
-->
