### PR TITLE
Require ruamel.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - futures >=3.0.0              # [py<34]
     - menuinst >=1.4.11,<2         # [win]
     - pip
-    - ruamel_yaml >=0.11.14,<0.16
+    - ruamel.yaml >=0.11.14,<0.16
     - setuptools >=31.0.1
   run:
     - python
@@ -43,7 +43,7 @@ requirements:
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
     - requests >=2.18.4,<3
-    - ruamel_yaml >=0.11.14,<0.16
+    - ruamel.yaml >=0.11.14,<0.16
     - setuptools >=31.0.1
   run_constrained:
     - conda-build >=3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.


### PR DESCRIPTION
Switches to requiring `ruamel.yaml` instead of `ruamel_yaml`.

cc @jjhelmus

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
