### PR TITLE
Fixup the conda-not-found bug

### DIFF
--- a/recipe/conda_not_found.patch
+++ b/recipe/conda_not_found.patch
@@ -1,0 +1,11 @@
+--- a/conda/shell/etc/bash_completion.d/conda	2019-11-04 12:30:49.000000000 -0500
++++ b/conda/shell/etc/bash_completion.d/conda	2019-12-15 11:38:04.094562891 -0500
+@@ -32,7 +32,7 @@
+             CONDA_ROOT=$(\dirname "${CONDA_ROOT}")
+         fi
+         CONDA_SOURCE=$(
+-            cat - <<'            EOF' | sed 's/^ *: //g' | python -
++            cat - <<'            EOF' | sed 's/^ *: //g' | ${CONDA_PYTHON_EXE} -
+             : from __future__ import print_function
+             : import os
+             : import conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
   sha256: 71f414b2914c9125c517bf3d5d1eda65791ff8162f8ad7f668d1633fad592041
   patches:
+    # Workaround for https://github.com/conda/conda/issues/9507
     - conda_not_found.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ source:
   fn: conda-{{ version }}.tar.gz
   url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
   sha256: 71f414b2914c9125c517bf3d5d1eda65791ff8162f8ad7f668d1633fad592041
+  patches:
+    - conda_not_found.patch
 
 build:
-  number: 0
+  number: 1
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.


### PR DESCRIPTION
Before and after
![image](https://user-images.githubusercontent.com/90008/70865913-9eb86f80-1f30-11ea-9267-94d12b6e1d53.png)

Workaround for https://github.com/conda/conda/issues/9507

I have no idea where this file is actually generated, but it is in the tar.gz that gets downloaded by this package.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
