### PR TITLE
4.8: remove archspec dep

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
   strategy:
     matrix:
       osx_64_python3.6.____73_pypypython_implpypy:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -30,7 +30,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables \
+    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0002-osx_arm64.patch
 
 build:
-  number: 1
+  number: 2
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.
@@ -53,7 +53,6 @@ requirements:
     - requests >=2.18.4,<3
     - ruamel_yaml >=0.11.14,<0.16
     - setuptools >=31.0.1
-    - archspec
   run_constrained:
     - conda-build >=3
     - conda-env >=2.6


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

`archspec` dependency is not used for `4.8` but only for future `>=4.9` releases: https://github.com/conda/conda/pull/9930

Also `archspec` is a `noarch: python`+`entry_points` package: https://github.com/conda-forge/archspec-feedstock/blob/ec0d74c7d30bfae74cf794690f097a26ea62f3f0/recipe/meta.yaml#L14-L16 .
Hence Windows users are very likely to hit https://github.com/conda/conda/issues?q=sort:updated-desc+cannot+link+to+a+source+that+does+not+exist when they update `conda` (and bring in `archspec`).

cc @johanneskoester