### PR TITLE
Remove setuptools in requirements/run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - gh9946_utf_16_replacement.patch
 
 build:
-  number: 0
+  number: 1
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.
@@ -53,7 +53,6 @@ requirements:
     - conda-build >=3
     - conda-env >=2.6
     - cytoolz >=0.8.1
-    - setuptools >=31.0.1
 
 test:
   source_files:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Reverts https://github.com/conda-forge/conda-feedstock/pull/138/commits/58695ca39251f531e142a6b1db35bcfe65296316.
cf: https://github.com/conda-forge/conda-feedstock/pull/108
cc @jakirkham

@chenghlee: It looks like in `conda`'s repository there are now two recipe folders (I didn't even notice that when I reviewed those PRs). `conda.recipe/meta.yaml` still carries the wrong `run_constrained` entries whereas `recipe/meta.yaml` has them fixed.