### PR TITLE
Bump conda-smithy selector to Python 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,7 +85,7 @@ test:
     - commands_to_test.bat           # [win]
     - commands_to_test.sh            # [unix]
   downstreams:
-    - conda-smithy  # [python_impl == "cpython" and py<311]
+    - conda-smithy  # [python_impl == "cpython" and py<312]
   commands:
     - env run_pytest={{ run_pytest }} bash test_runner.sh   # [unix]
     - set run_pytest={{ run_pytest }} && .\test_runner.bat  # [win]


### PR DESCRIPTION
Since this will be encountered again during the next Python migration, just bump the Python version in the downstream test selector. This way that migration can go through smoothly and we can bump once conda-smithy is installable with the next Python version.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
