### PR TITLE
Re-enable Windows and PyPy builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,8 +16,16 @@ jobs:
         CONFIG: linux_64_python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_64_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.8.____cpythonpython_implcpython:
         CONFIG: linux_64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_64_python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.9.____cpythonpython_implcpython:
@@ -32,8 +40,16 @@ jobs:
         CONFIG: linux_aarch64_python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_python3.8.____cpythonpython_implcpython:
         CONFIG: linux_aarch64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_python3.9.____cpythonpython_implcpython:
@@ -48,8 +64,16 @@ jobs:
         CONFIG: linux_ppc64le_python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_ppc64le_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_python3.8.____cpythonpython_implcpython:
         CONFIG: linux_ppc64le_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_ppc64le_python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_python3.9.____cpythonpython_implcpython:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,8 +14,14 @@ jobs:
       osx_64_python3.11.____cpythonpython_implcpython:
         CONFIG: osx_64_python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____73_pypypython_implpypy:
+        CONFIG: osx_64_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
       osx_64_python3.8.____cpythonpython_implcpython:
         CONFIG: osx_64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____73_pypypython_implpypy:
+        CONFIG: osx_64_python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
       osx_64_python3.9.____cpythonpython_implcpython:
         CONFIG: osx_64_python3.9.____cpythonpython_implcpython

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,23 +8,8 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      win_64_python3.10.____cpythonpython_implcpython:
-        CONFIG: win_64_python3.10.____cpythonpython_implcpython
-        UPLOAD_PACKAGES: 'True'
-      win_64_python3.11.____cpythonpython_implcpython:
-        CONFIG: win_64_python3.11.____cpythonpython_implcpython
-        UPLOAD_PACKAGES: 'True'
-      win_64_python3.8.____73_pypypython_implpypy:
-        CONFIG: win_64_python3.8.____73_pypypython_implpypy
-        UPLOAD_PACKAGES: 'True'
-      win_64_python3.8.____cpythonpython_implcpython:
-        CONFIG: win_64_python3.8.____cpythonpython_implcpython
-        UPLOAD_PACKAGES: 'True'
       win_64_python3.9.____73_pypypython_implpypy:
         CONFIG: win_64_python3.9.____73_pypypython_implpypy
-        UPLOAD_PACKAGES: 'True'
-      win_64_python3.9.____cpythonpython_implcpython:
-        CONFIG: win_64_python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,8 +14,14 @@ jobs:
       win_64_python3.11.____cpythonpython_implcpython:
         CONFIG: win_64_python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____73_pypypython_implpypy:
+        CONFIG: win_64_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
       win_64_python3.8.____cpythonpython_implcpython:
         CONFIG: win_64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____73_pypypython_implpypy:
+        CONFIG: win_64_python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
       win_64_python3.9.____cpythonpython_implcpython:
         CONFIG: win_64_python3.9.____cpythonpython_implcpython
@@ -23,7 +29,6 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
-    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -82,9 +87,6 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
-        set "TEMP=$(UPLOAD_TEMP)"
-        if not exist "%TEMP%\" md "%TEMP%"
-        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -35,7 +35,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install "python=3.9" conda-build=3.23.0 conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build=3.22.0 conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -35,7 +35,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build=3.23.0 conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.ci_support/linux_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf @jakirkham @jezdez @kalefranz @mbargull @mingwandroid @msarahan @mwcraig @ocefpaf @patricksnape @pelson @scopatz
+* @isuruf @jakirkham @jezdez @kalefranz @mbargull @mcg1969 @mingwandroid @msarahan @mwcraig @ocefpaf @patricksnape @pelson @scopatz

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: OS-agnostic, system-level binary package and environment manager.
 
 Development: https://github.com/conda/conda
 
-Documentation: https://docs.conda.io/projects/conda/en/stable/
+Documentation: https://conda.io/projects/conda/en/latest/
 
 Conda is an open source package management system and environment management system for installing multiple versions of software packages and their dependencies and switching easily between them. It works on Linux, OS X and Windows, and was created for Python programs but can package and distribute any software.
 
@@ -48,10 +48,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -76,10 +90,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -104,10 +132,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -132,10 +174,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -188,10 +244,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=174&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -335,6 +405,7 @@ Feedstock Maintainers
 * [@jezdez](https://github.com/jezdez/)
 * [@kalefranz](https://github.com/kalefranz/)
 * [@mbargull](https://github.com/mbargull/)
+* [@mcg1969](https://github.com/mcg1969/)
 * [@mingwandroid](https://github.com/mingwandroid/)
 * [@msarahan](https://github.com/msarahan/)
 * [@mwcraig](https://github.com/mwcraig/)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,4 @@
 # -*- mode: yaml -*-
 
 jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,5 +10,3 @@ provider:
   linux_aarch64: default
   linux_ppc64le: default
 test_on_native_only: true
-conda_build:
-  pkg_format: '2'

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,6 @@ FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i
 set MSYSTEM=MINGW%ARCH%
 set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1
-bash -lc ./build.sh
+bash -le ./build.sh
 if %errorlevel% neq 0 exit /b %errorlevel%
 exit /b 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,6 @@ FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i
 set MSYSTEM=MINGW%ARCH%
 set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1
-bash -le ./build.sh
+bash -e ./build.sh
 if %errorlevel% neq 0 exit /b %errorlevel%
 exit /b 0

--- a/recipe/gh9946_utf_16_replacement.patch
+++ b/recipe/gh9946_utf_16_replacement.patch
@@ -1,0 +1,119 @@
+diff --color -Naur conda-22.9.0.orig/conda/core/portability.py conda-22.9.0/conda/core/portability.py
+--- conda-22.9.0.orig/conda/core/portability.py	2022-06-29 23:30:51.000000000 -0300
++++ conda-22.9.0/conda/core/portability.py	2022-09-09 16:15:55.872345749 -0300
+@@ -3,6 +3,9 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ from __future__ import absolute_import, division, print_function, unicode_literals
+ 
++# force encodings to be available when updating python.
++# xref.: https://github.com/conda-forge/conda-feedstock/pull/135
++from encodings import utf_8, utf_16, utf_16_le, utf_16_be, utf_32, utf_32_le, utf_32_be
+ from logging import getLogger
+ from os.path import realpath
+ import re
+@@ -77,34 +80,52 @@ def update_prefix(
+ 
+ 
+ def replace_prefix(mode, data, placeholder, new_prefix):
+-    if mode == FileMode.text:
+-        if not on_win:
+-            # if new_prefix contains spaces, it might break the shebang!
+-            # handle this by escaping the spaces early, which will trigger a
+-            # /usr/bin/env replacement later on
+-            newline_pos = data.find(b"\n")
+-            if newline_pos > -1:
+-                shebang_line, rest_of_data = data[:newline_pos], data[newline_pos:]
+-                shebang_placeholder = f"#!{placeholder}".encode('utf-8')
+-                if shebang_placeholder in shebang_line:
+-                    escaped_shebang = f"#!{new_prefix}".replace(" ", "\\ ").encode('utf-8')
+-                    shebang_line = shebang_line.replace(shebang_placeholder, escaped_shebang)
+-                    data = shebang_line + rest_of_data
+-        # the rest of the file can be replaced normally
+-        data = data.replace(placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
+-    elif mode == FileMode.binary:
+-        data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
+-    else:
+-        raise CondaIOError("Invalid mode: %r" % mode)
++    popular_encodings = [
++        "utf-8",
++        # Make sure to specify -le and -be so that the UTF endian prefix
++        # doesn't show up in the string
++        "utf-16-le",
++        "utf-16-be",
++        "utf-32-le",
++        "utf-32-be",
++    ]
++    for encoding in popular_encodings:
++        if mode == FileMode.text:
++            if not on_win:
++                # if new_prefix contains spaces, it might break the shebang!
++                # handle this by escaping the spaces early, which will trigger a
++                # /usr/bin/env replacement later on
++                newline_pos = data.find(b"\n")
++                if newline_pos > -1:
++                    shebang_line, rest_of_data = data[:newline_pos], data[newline_pos:]
++                    shebang_placeholder = f"#!{placeholder}".encode(encoding)
++                    if shebang_placeholder in shebang_line:
++                        escaped_shebang = f"#!{new_prefix}".replace(" ", "\\ ").encode(encoding)
++                        shebang_line = shebang_line.replace(shebang_placeholder, escaped_shebang)
++                        data = shebang_line + rest_of_data
++            # the rest of the file can be replaced normally
++            data = data.replace(placeholder.encode(encoding), new_prefix.encode(encoding))
++        elif mode == FileMode.binary:
++            data = binary_replace(
++                data, placeholder.encode(encoding), new_prefix.encode(encoding), encoding=encoding
++            )
++        else:
++            raise CondaIOError("Invalid mode: %r" % mode)
+     return data
+ 
+ 
+-def binary_replace(data, a, b):
++def binary_replace(data, a, b, encoding='utf-8'):
+     """
+     Perform a binary replacement of `data`, where the placeholder `a` is
+     replaced with `b` and the remaining string is padded with null characters.
+     All input arguments are expected to be bytes objects.
++
++    Parameters
++    ----------
++    encoding: str
++        The encoding of the expected string in the binary.
+     """
++    zeros = '\0'.encode(encoding)
+     if on_win:
+         # on Windows for binary files, we currently only replace a pyzzer-type entry point
+         #   we skip all other prefix replacement
+@@ -121,7 +142,10 @@ def binary_replace(data, a, b):
+         return match.group().replace(a, b) + b'\0' * padding
+ 
+     original_data_len = len(data)
+-    pat = re.compile(re.escape(a) + b'([^\0]*?)\0')
++    pat = re.compile(
++        re.escape(a) +
++        b'(?:(?!(?:' + zeros + b')).)*' + zeros
++    )
+     data = pat.sub(replace, data)
+     assert len(data) == original_data_len
+ 
+diff --color -Naur conda-22.9.0.orig/tests/test_install.py conda-22.9.0/tests/test_install.py
+--- conda-22.9.0.orig/tests/test_install.py	2022-06-29 23:30:51.000000000 -0300
++++ conda-22.9.0/tests/test_install.py	2022-09-09 16:16:53.941678976 -0300
+@@ -34,9 +34,14 @@
+ 
+     @pytest.mark.xfail(on_win, reason="binary replacement on windows skipped", strict=True)
+     def test_simple(self):
+-        self.assertEqual(
+-            binary_replace(b'xxxaaaaaxyz\x00zz', b'aaaaa', b'bbbbb'),
+-            b'xxxbbbbbxyz\x00zz')
++        for encoding in ['utf-8', 'utf-16-le', 'utf-16-be', 'utf-32-le', 'utf-32-be']:
++            a = 'aaaaa'.encode(encoding)
++            b = 'bbbb'.encode(encoding)
++            data   = 'xxxaaaaaxyz\0zz'.encode(encoding)
++            result = 'xxxbbbbxyz\0\0zz'.encode(encoding)
++            self.assertEqual(
++                binary_replace(data, a, b, encoding=encoding),
++                result)
+ 
+     @pytest.mark.xfail(on_win, reason="binary replacement on windows skipped", strict=True)
+     def test_shorter(self):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set on_win = SUBDIR in ('win-64', 'win-32') %}
-{% set name = "conda" %}
-{% set version = "22.11.0" %}
-{% set sha256 = "f280c1e68601adbfacb63d71d7319b0067f9e2543bb56b98d8093d22617ee42e" %}
+{% set version = "22.9.0" %}
 # Running pytest requires the inclusion of test files which baloons
 # the size of the package; values can be "yes" or "no"
 {% set run_pytest = "no" %}
@@ -12,12 +10,13 @@ package:
 
 source:
   fn: conda-{{ version }}.tar.gz
-  url: https://github.com/conda/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
+  sha256: 35c924fab82e1be7a3359494ff02eab2b2d9b04004cc689e41f84edc1fb853c0
+  patches:
+    - gh9946_utf_16_replacement.patch
 
 build:
-  skip: True                       # [python_impl == 'pypy']
-  number: 0
+  number: 2
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.
@@ -42,11 +41,9 @@ requirements:
     - conda-package-handling >=1.3.0
     - menuinst >=1.4.11,<2         # [win]
     - pip
-    - ruamel.yaml >=0.11.14,<0.18
+    - ruamel_yaml >=0.11.14,<0.17
     - setuptools >=31.0.1
     - toolz >=0.8.1
-    - pluggy >=1.0.0
-    - tqdm >=4
   run:
     - python
     - conda-package-handling >=1.3.0
@@ -54,11 +51,9 @@ requirements:
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
     - requests >=2.20.1,<3
-    - ruamel.yaml >=0.11.14,<0.18
+    - ruamel_yaml >=0.11.14,<0.17
     - setuptools >=31.0.1
     - toolz >=0.8.1
-    - pluggy >=1.0.0
-    - tqdm >=4
   run_constrained:
     - conda-build >=3
     - conda-content-trust >=0.1.1
@@ -102,7 +97,7 @@ about:
   summary: OS-agnostic, system-level binary package and environment manager.
   description: >
     Conda is an open source package management system and environment management system for installing multiple versions of software packages and their dependencies and switching easily between them. It works on Linux, OS X and Windows, and was created for Python programs but can package and distribute any software.
-  doc_url: https://docs.conda.io/projects/conda/en/stable/
+  doc_url: https://conda.io/projects/conda/en/latest/
   dev_url: https://github.com/conda/conda
 
 extra:
@@ -110,6 +105,7 @@ extra:
     - isuruf
     - jakirkham
     - kalefranz
+    - mcg1969
     - mingwandroid
     - msarahan
     - mwcraig


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
PyPy builds failed on Windows in gh-181.
Debugging/trying to re-enable them here.