### PR TITLE
constrain conda-libmamba-solver >=22.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,7 @@ requirements:
     - conda-content-trust >=0.1.1
     - conda-env >=2.6
     - cytoolz >=0.8.1
+    - conda-libmamba-solver >=22.11.0
 
 test:
 {% if run_pytest == 'yes' %}


### PR DESCRIPTION
Older conda-libmamba-solver is useless with newer conda

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
