### PR TITLE
Add patch from upstream PR for Python 3.13 compatibility.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,10 @@ source:
   fn: conda-{{ version }}.tar.gz
   url: https://github.com/conda/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    # Backport https://github.com/conda/conda/pull/14117 for changes in the
+    # Python 3.13+ logging module internals
+    - patches/0001-GH-14117-logging-lock-internal-changes-py313.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/0001-GH-14117-logging-lock-internal-changes-py313.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv && {{ PYTHON }} -m conda init --install
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files

--- a/recipe/patches/0001-GH-14117-logging-lock-internal-changes-py313.patch
+++ b/recipe/patches/0001-GH-14117-logging-lock-internal-changes-py313.patch
@@ -1,0 +1,68 @@
+From 62196c897df3d7aea7063d0c08d1bf6e6fd91600 Mon Sep 17 00:00:00 2001
+From: "Benjamin A. Beasley" <code@musicinmybrain.net>
+Date: Fri, 2 Aug 2024 08:50:43 -0400
+Subject: [PATCH 1/2] Adapt for logging lock internal changes in Python 3.13
+
+---
+ conda/common/io.py | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/conda/common/io.py b/conda/common/io.py
+index 91f37e144d0..d3b655e47f4 100644
+--- a/conda/common/io.py
++++ b/conda/common/io.py
+@@ -269,11 +269,16 @@ def argv(args_list):
+ 
+ @contextmanager
+ def _logger_lock():
+-    logging._acquireLock()
++    try:
++        # Python 3.13+
++        acquire, release = logging._prepareFork, logging._afterFork
++    except AttributeError:
++        acquire, release = logging._acquireLock, logging._releaseLock
++    acquire()
+     try:
+         yield
+     finally:
+-        logging._releaseLock()
++        release()
+ 
+ 
+ @contextmanager
+
+From 78cd209128292371d9d2abbca7b3d1f4912d1c49 Mon Sep 17 00:00:00 2001
+From: "Benjamin A. Beasley" <code@musicinmybrain.net>
+Date: Mon, 5 Aug 2024 10:52:49 -0400
+Subject: [PATCH 2/2] Add news item for PR#14117
+
+---
+ news/14117-logging-lock-changes | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+ create mode 100644 news/14117-logging-lock-changes
+
+diff --git a/news/14117-logging-lock-changes b/news/14117-logging-lock-changes
+new file mode 100644
+index 00000000000..7f708aa0eed
+--- /dev/null
++++ b/news/14117-logging-lock-changes
+@@ -0,0 +1,19 @@
++### Enhancements
++
++* <news item>
++
++### Bug fixes
++
++* <news item>
++
++### Deprecations
++
++* <news item>
++
++### Docs
++
++* <news item>
++
++### Other
++
++* Adapt for logging lock internal changes in Python 3.13 (#14117)


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I am trying to help unblock Python 3.13 builds in #249.

I did some work locally to try and unblock the builds, and found that this patch https://github.com/conda/conda/pull/14117 was a prerequisite to make builds work. This patch is not enough on its own, as there are circular dependency issues. More details on those here: https://github.com/conda-forge/conda-feedstock/issues/246#issuecomment-2629559879
