### PR TITLE
Tighten constraint on conda-libmamba-solver from 24.11.0 to 25.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - archspec >=0.2.3
     - boltons >=23.0.0
     - charset-normalizer
-    - conda-libmamba-solver >=24.11.0
+    - conda-libmamba-solver >=25.4.0
     - conda-package-handling >=2.2.0
     - distro >=1.5.0
     - frozendict >=2.4.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   folder: conda-src
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install conda-src/ --no-deps --no-build-isolation -vv && {{ PYTHON }} -m conda init --install
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files


### PR DESCRIPTION
Due to the removal of deprecated functions in conda 25.9.0, older versions of conda-libmamba-solver are incompatible with conda 25.9.0. While conda-libmamba-solver 25.4.0 includes fixes which should address these changes, conda still has an older minimum bound. Thus users can upgrade conda, but get stuck with an incompatible conda-libmamba-solver. To address this bump the minimum version of conda-libmamba-solver used by conda.

More details in the upstream issue linked below.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

References:
* https://github.com/conda/conda/issues/15287