### PR TITLE
Bump build number to 1 for conda 26.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   folder: conda-src
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install conda-src/ --no-deps --no-build-isolation -vv && {{ PYTHON }} -m conda init --install
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files


### PR DESCRIPTION
## Summary

- Bumps `build: number` from `0` to `1` to trigger a fresh Azure Pipelines rebuild
- The `osx-64 py312` variant failed to publish in build 0 (see failed Azure job https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1501014&view=logs&jobId=899534ae-d486-52b7-7b1c-5c9a77433eb6)
- All other platform/Python combinations published successfully; this rebuild will fill the gap

No source or dependency changes.