### PR TITLE
Restore prefix relocation for conda launchers

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,12 +14,18 @@ source:
   target_directory: conda-src
 
 build:
-  number: 1
+  number: 2
   script:
     content:
       # Prevents issues like https://github.com/conda-forge/conda-feedstock/issues/280
       - rm -rf conda-src/tests/
       - ${{ PYTHON }} -m pip install conda-src/ --no-deps --no-build-isolation -vv && ${{ PYTHON }} -m conda init --install
+      # conda-build rewrites these launchers to use the environment's Python,
+      # but rattler-build requires an explicit prefix to detect and relocate.
+      - if: unix
+        then:
+          - sed -i.bak "1s|.*|#!${{ PYTHON }}|" "$PREFIX/bin/conda" "$PREFIX/condabin/conda"
+          - rm "$PREFIX/bin/conda.bak" "$PREFIX/condabin/conda.bak"
   always_include_files:
     # These are present when the new environment is created
     # so we have to exempt them from the list of initial files

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,6 +22,7 @@ build:
       - ${{ PYTHON }} -m pip install conda-src/ --no-deps --no-build-isolation -vv && ${{ PYTHON }} -m conda init --install
       # conda-build rewrites these launchers to use the environment's Python,
       # but rattler-build requires an explicit prefix to detect and relocate.
+      # Prevents issues like https://github.com/conda-forge/conda-feedstock/issues/304
       - if: unix
         then:
           - sed -i.bak "1s|.*|#!${{ PYTHON }}|" "$PREFIX/bin/conda" "$PREFIX/condabin/conda"

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -13,12 +13,15 @@ eval "$(python -m conda shell.bash hook)"
 conda info --all
 
 # create, activate, and deactivate a conda environment
-conda create --yes -c conda-forge --prefix "./built-conda-test-env" "patch" || exit 1
+conda create --yes -c conda-forge --prefix "./built-conda-test-env" "patch" "python" || exit 1
 
 conda activate "./built-conda-test-env"
 echo "CONDA_PREFIX=${CONDA_PREFIX}"
 
 [[ "${CONDA_PREFIX}" == "${PWD}/built-conda-test-env" ]] || exit 1
 ${CONDA_PREFIX}/bin/patch --version || exit 1
+# Regression test for https://github.com/conda-forge/conda-feedstock/issues/304
+# Ensure conda continues to use its own Python when another environment is active.
+conda --version || exit 1
 
 conda deactivate


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

Closes #304, closes #305.

The rattler-build migration changed the generated Unix `conda` launchers from prefix-relocatable shebangs to `#!/usr/bin/env python`. When another environment containing Python is active, the launchers consequently use that environment's interpreter and fail to import `conda`.

This rewrites the two Unix launcher shebangs to `${{ PYTHON }}` after `conda init --install`, allowing rattler-build to record and relocate the build prefix. The regression test now activates a child environment containing its own Python before invoking `conda`.

Validation:

* Confirmed the regression test fails against build `_1` with `ModuleNotFoundError: No module named 'conda'`.
* Built and tested the updated recipe with rattler-build for Python 3.14 on Linux.
* Confirmed `bin/conda` and `condabin/conda` are recorded as text-prefix-relocatable files.
