### PR TITLE
Use `conda-launchers` binaries for `cli-64.exe`

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -82,9 +82,9 @@ requirements:
     # Plugins to bundle with conda
     - conda-libmamba-solver >=26.4.1
     - conda-lockfiles >=0.2.0
-    - conda-self >=0.2.0
     - conda-pypi >=0.9.0
     - conda-rattler-solver >=0.1.1
+    - conda-self >=0.2.0
   run_constraints:
     - conda-build >=25.9
     - conda-content-trust >=0.3.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,16 +9,21 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/conda/conda/releases/download/${{ version }}/conda-${{ version }}.tar.gz
-  sha256: ${{ sha256 }}
-  target_directory: conda-src
+  - url: https://github.com/conda/conda/releases/download/${{ version }}/conda-${{ version }}.tar.gz
+    sha256: ${{ sha256 }}
+    target_directory: conda-src
+  # These Windows launchers are built in public CI and signed with community-owned certificates
+  - url: https://github.com/conda/conda-launchers/releases/download/24.7.1-5/cli-64-24.7.1-e8b2e36_gcc_5.exe
+    sha256: 4d8c479577961d0c6d940966f7987fbb0d6fc98b80edc03b00ee949dd8c1b3e2
+    target_directory: signed-launchers
 
 build:
-  number: 1
+  number: 2
   script:
     content:
       # Prevents issues like https://github.com/conda-forge/conda-feedstock/issues/280
       - rm -rf conda-src/tests/
+      - cp signed-launchers/cli-64-24.7.1-e8b2e36_gcc_5.exe conda-src/conda/shell/cli-64.exe
       - ${{ PYTHON }} -m pip install conda-src/ --no-deps --no-build-isolation -vv && ${{ PYTHON }} -m conda init --install
   always_include_files:
     # These are present when the new environment is created


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

These binaries are signed by NumFOCUS certificates instead of Anaconda's.